### PR TITLE
Better regex for Telegram usernames

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -106,7 +106,7 @@ fn parse_time_arg(s: &str) -> Result<NaiveTime, chrono::ParseError> {
 fn parse_username_arg(s: String) -> Option<Username> {
     lazy_static! {
         // Construct a regex that matches `@username`.
-        static ref RE: Regex = Regex::new(r"^@(\S+)$").unwrap();
+        static ref RE: Regex = Regex::new(r"^@(\w{5,32})$").unwrap();
     }
 
     let caps = RE.captures(&s)?;


### PR DESCRIPTION
Correct regex for Telegram usernames, https://telegram.org/faq#q-what-can-i-use-as-my-username