### PR TITLE
Add Pokemon command

### DIFF
--- a/src/bot.rs
+++ b/src/bot.rs
@@ -229,6 +229,21 @@ pub async fn handle_cmd(sc: StateContainer, bot: Bot, msg: Message, cmd: Command
 
             send_msg(&bot, &chat_id, &text, false).await
         }
+
+        Command::Pokemon => {
+            let current_datetime = Utc::now().with_timezone(&Helsinki);
+            let mornings = calculate_mornings(current_datetime).unwrap();
+
+            let text = match mornings {
+                Mornings::End(num_days, _) => format!(
+                    "https://raw.githubusercontent.com/HybridShivam/Pokemon/master/assets/images/{:03}.png",
+                    num_days
+                ),
+                Mornings::Disabled => return None,
+            };
+
+            send_msg(&bot, &chat_id, &text, false).await
+        }
     }
 
     Some(())

--- a/src/command.rs
+++ b/src/command.rs
@@ -43,6 +43,9 @@ pub enum Command {
 
     /// Tänään jäljellä
     Tj,
+
+    /// Shows an image of the Pokemon that matches the current TJ
+    Pokemon,
 }
 
 impl Command {
@@ -149,6 +152,7 @@ pub fn parse_cmd(text: &str) -> Result<Option<Command>, Box<dyn std::error::Erro
                     for_user,
                 })
             }
+            "pokemon" => Some(Command::Pokemon),
             _ => {
                 if matches_tj_regex(&cmd) {
                     Some(Command::Tj)


### PR DESCRIPTION
The bot will respond to the command with a link to an image of a Pokemon
which ID is the current TJ. When the link is sent to Telegram by the
bot, it will (depending on the client and settings) expand to the full
image that is then shown in the chat.