### PR TITLE
Parse ranks correctly

### DIFF
--- a/src/commands/stats.rs
+++ b/src/commands/stats.rs
@@ -13,7 +13,9 @@ fn index_to_pos(index: usize) -> String {
 }
 
 fn skill_level_to_cs2_rank(skill_level: u32) -> String {
+    let unranked_text = "Unranked";
     let ranks = [
+        unranked_text,
         "Silver I",
         "Silver II",
         "Silver III",
@@ -37,7 +39,7 @@ fn skill_level_to_cs2_rank(skill_level: u32) -> String {
     if skill_level < 1000 {
         let rank = ranks
             .get(skill_level as usize)
-            .unwrap_or(&"Unranked")
+            .unwrap_or(&unranked_text)
             .to_string();
 
         format!("{skill_level}, {rank}")


### PR DESCRIPTION
We are getting the "skill level":th element from the list to show the rank. If the Leetify API returns a 0, it means the player is unranked. A Skill Level of 4 would mean the player is a Silver IV, which means the fourth element should be returned.

Before this change, there would be an off by one error that made the ranks show the wrong one. By adding the unranked text as well to the list, we can avoid having to deal with "-1" in places, and have a 1-1 mapping of list index->rank.