### PR TITLE
Support 15 minute electricity pricing

### DIFF
--- a/src/services/porssisahko.rs
+++ b/src/services/porssisahko.rs
@@ -38,7 +38,7 @@ pub async fn get_price_chart() -> Result<Vec<u8>> {
         .flat_map(|hp| {
             [*hp, {
                 let mut hp = *hp;
-                hp.start_date += Duration::hours(1) - Duration::nanoseconds(1);
+                hp.start_date += Duration::minutes(15) - Duration::nanoseconds(1);
                 hp
             }]
         })
@@ -167,7 +167,7 @@ pub async fn get_price_chart() -> Result<Vec<u8>> {
 #[cached(result = true, time = 60)]
 async fn get_latest_prices() -> Result<Vec<HourlyPrice>> {
     println!("Fetching latest sahko prices");
-    let url = "https://api.porssisahko.net/v1/latest-prices.json";
+    let url = "https://api.porssisahko.net/v2/latest-prices.json";
     let resp: PricesResult = reqwest::get(url).await?.json().await?;
 
     // For some reason the API returns the prices in reverse order


### PR DESCRIPTION
We switch from the v1 to v2 API, which returns a list of prices per 15 minutes instead of the previously used 1 hour interval. The API is already returning the 15 minute times in preparation for the upcoming change to this system.

As we are drawing the bar chart, we also need to update the "width" of each column, as we are currently drawing "1 hour" forward, we now need to draw 15 minutes forward.

There might still be an edge case (hehe) with how the initial hour is handled and how the chart will look at different times, as the previous APIs first element in the returned data was always an even hour, but now it can be 00, 15, 30 or 45 minutes past. Based on quick testing it does not look different though.