### PR TITLE
Color electricity chart area blue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,6 @@ plotters = { version = "=0.3.7", default-features = false, features = [
     "bitmap_backend",
     # "svg_backend",
     "chrono",
-    "line_series",
+    "area_series",
 ] }
 image = { version = "=0.25.8", features = ["png"] }

--- a/src/services/porssisahko.rs
+++ b/src/services/porssisahko.rs
@@ -5,7 +5,7 @@ use color_eyre::{eyre::eyre, Result};
 use plotters::{
     chart::{ChartBuilder, LabelAreaPosition},
     prelude::{BitMapBackend, IntoDrawingArea, Rectangle},
-    series::LineSeries,
+    series::AreaSeries,
     style::{self, register_font, Color, FontStyle, IntoFont, BLACK, BLUE, RED, WHITE},
 };
 use serde::Deserialize;
@@ -115,15 +115,19 @@ pub async fn get_price_chart() -> Result<Vec<u8>> {
             .y_max_light_lines(2)
             .draw()?;
 
-        ctx.draw_series(LineSeries::new(
-            prices.iter().map(|hp| {
-                (
-                    hp.start_date.with_timezone(&chrono_tz::Europe::Helsinki),
-                    hp.price,
-                )
-            }),
-            &BLUE,
-        ))?;
+        ctx.draw_series(
+            AreaSeries::new(
+                prices.iter().map(|hp| {
+                    (
+                        hp.start_date.with_timezone(&chrono_tz::Europe::Helsinki),
+                        hp.price,
+                    )
+                }),
+                0.0,
+                BLUE.mix(0.2),
+            )
+            .border_style(BLUE),
+        )?;
 
         let cur_price_line_thickness = Duration::minutes(6);
 


### PR DESCRIPTION
This will make the area under the current price line be slightly transparently blue, making it easier to read the chart with the 15-minute interval prices as the line jumps quite a lot in those cases.