### PR TITLE
Add colors to electicity chart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,7 @@ dependencies = [
  "chrono-tz",
  "clap",
  "color-eyre",
+ "colorous",
  "config",
  "futures",
  "image",
@@ -516,6 +517,12 @@ checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "colorous"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e18bf7a165bf7028fde98609a0f1e8f7498d762a212598e6c891f6893556ec"
 
 [[package]]
 name = "config"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,4 @@ plotters = { version = "=0.3.7", default-features = false, features = [
     "line_series",
 ] }
 image = { version = "=0.25.8", features = ["png"] }
+colorous = "1.0.16"

--- a/src/services/porssisahko.rs
+++ b/src/services/porssisahko.rs
@@ -1,3 +1,5 @@
+use std::cmp::{max, min};
+
 use cached::proc_macro::cached;
 use chrono::{DateTime, Duration, Timelike, Utc};
 use chrono_tz::Tz;
@@ -5,8 +7,7 @@ use color_eyre::{eyre::eyre, Result};
 use plotters::{
     chart::{ChartBuilder, LabelAreaPosition},
     prelude::{BitMapBackend, IntoDrawingArea, Rectangle},
-    series::LineSeries,
-    style::{self, register_font, Color, FontStyle, IntoFont, BLACK, BLUE, RED, WHITE},
+    style::{self, register_font, Color, FontStyle, IntoFont, RGBColor, BLACK, RED, WHITE},
 };
 use serde::Deserialize;
 
@@ -35,18 +36,6 @@ pub async fn get_price_chart() -> Result<Vec<u8>> {
         .fold(f32::NEG_INFINITY, |a, &b| a.max(b.price))
         .max(10.);
     let min_price = prices.iter().fold(0.0f32, |a, &b| a.min(b.price));
-
-    // Simulate a bar chart
-    let prices = prices
-        .iter()
-        .flat_map(|hp| {
-            [*hp, {
-                let mut hp = *hp;
-                hp.start_date += Duration::minutes(15) - Duration::nanoseconds(1);
-                hp
-            }]
-        })
-        .collect::<Vec<_>>();
 
     // Generate a chart
     let width: usize = 1024;
@@ -119,15 +108,50 @@ pub async fn get_price_chart() -> Result<Vec<u8>> {
             .y_max_light_lines(2)
             .draw()?;
 
-        ctx.draw_series(LineSeries::new(
-            prices.iter().map(|hp| {
-                (
-                    hp.start_date.with_timezone(&chrono_tz::Europe::Helsinki),
-                    hp.price,
-                )
-            }),
-            &BLUE,
-        ))?;
+        ctx.draw_series(prices.iter().map(|hp| {
+            Rectangle::new(
+                [
+                    (
+                        hp.start_date.with_timezone(&chrono_tz::Europe::Helsinki),
+                        0.0,
+                    ),
+                    (
+                        (hp.start_date + Duration::minutes(15))
+                            .with_timezone(&chrono_tz::Europe::Helsinki),
+                        hp.price,
+                    ),
+                ],
+                {
+                    let gradient = colorous::VIRIDIS;
+
+                    // We scale up the prices from 0.xx cents to something more usize friendly, as we need
+                    // that later to get the color gradient.
+                    let scale_up = 100;
+                    let current_price = (hp.price * scale_up as f32) as usize;
+
+                    // We "push" values up a bit artificially, so that we can avoid the first part of the color gradient.
+                    let tulttans_constant = 0.2;
+
+                    // This determins how dark the darkest price is. In the future, it could maybe be based on the
+                    // highest price of the day?
+                    let max_price: f32 = (30 * scale_up) as f32;
+                    let tulttans_max_price = (max_price * (1.0 + tulttans_constant)) as usize;
+
+                    // We "push" values up a bit artificially, so that we can avoid the first part of the color gradient.
+                    let tulttans_fix_to_avoid_spy_color = (tulttans_constant * max_price) as usize;
+
+                    let cor = gradient.eval_rational(
+                        tulttans_max_price
+                            - min(
+                                max(current_price, 0) + tulttans_fix_to_avoid_spy_color,
+                                tulttans_max_price,
+                            ),
+                        tulttans_max_price,
+                    );
+                    RGBColor(cor.r, cor.g, cor.b).filled()
+                },
+            )
+        }))?;
 
         let cur_price_line_thickness = Duration::minutes(6);
 


### PR DESCRIPTION
This PR adds colors to the electricity price chart. Currently the "max" value for the darkest color is hardcoded, but that could potentially be changed for the future.